### PR TITLE
Fix bug in computing gradient penalty

### DIFF
--- a/WGAN_GP.py
+++ b/WGAN_GP.py
@@ -115,7 +115,7 @@ class WGAN_GP(object):
         interpolates = self.inputs + (alpha * differences)
         _,D_inter,_=self.discriminator(interpolates, is_training=True, reuse=True)
         gradients = tf.gradients(D_inter, [interpolates])[0]
-        slopes = tf.sqrt(tf.reduce_sum(tf.square(gradients), reduction_indices=[1]))
+        slopes = tf.sqrt(tf.reduce_sum(tf.square(gradients), axis=[1, 2, 3]))
         gradient_penalty = tf.reduce_mean((slopes - 1.) ** 2)
         self.d_loss += self.lambd * gradient_penalty
 


### PR DESCRIPTION
This is a shameful bug... Obviously the part I edited was copied directly from the Github repo of improved training for Wasserstein GANs. However, in the author's code, the image was first flatten to a matrix, that's why the reduction axis was only for [1]. In this implementation, we should use reduction axis [1, 2, 3] because we don't flatten images.